### PR TITLE
Add Java and Angular SaaS skeleton

### DIFF
--- a/saas/README.md
+++ b/saas/README.md
@@ -1,0 +1,28 @@
+# SaaS Example
+
+This folder provides a minimal proof of concept for a SaaS application with a
+Java backend and an Angular frontend.
+
+## Backend
+
+The backend uses Spring Boot with Gradle. To run it:
+
+```bash
+cd backend
+gradle bootRun
+```
+
+A single endpoint is exposed at `GET /api/hello`.
+
+## Frontend
+
+The frontend contains a lightweight Angular setup. To serve it in development
+mode you will need the Angular CLI:
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+This will start the Angular development server on port 4200.

--- a/saas/backend/build.gradle
+++ b/saas/backend/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.2.3'
+    id 'io.spring.dependency-management' version '1.1.4'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+sourceCompatibility = '17'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/saas/backend/settings.gradle
+++ b/saas/backend/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'saas-backend'

--- a/saas/backend/src/main/java/com/example/saas/SaasApplication.java
+++ b/saas/backend/src/main/java/com/example/saas/SaasApplication.java
@@ -1,0 +1,12 @@
+package com.example.saas;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SaasApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SaasApplication.class, args);
+    }
+}

--- a/saas/backend/src/main/java/com/example/saas/controller/HelloController.java
+++ b/saas/backend/src/main/java/com/example/saas/controller/HelloController.java
@@ -1,0 +1,13 @@
+package com.example.saas.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/api/hello")
+    public String hello() {
+        return "Hello, world!";
+    }
+}

--- a/saas/backend/src/test/java/com/example/saas/SaasApplicationTests.java
+++ b/saas/backend/src/test/java/com/example/saas/SaasApplicationTests.java
@@ -1,0 +1,12 @@
+package com.example.saas;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class SaasApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+}

--- a/saas/frontend/package.json
+++ b/saas/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "saas-frontend",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "ng serve",
+    "build": "ng build"
+  },
+  "dependencies": {
+    "@angular/animations": "~17.0.0",
+    "@angular/common": "~17.0.0",
+    "@angular/compiler": "~17.0.0",
+    "@angular/core": "~17.0.0",
+    "@angular/forms": "~17.0.0",
+    "@angular/platform-browser": "~17.0.0",
+    "@angular/platform-browser-dynamic": "~17.0.0",
+    "rxjs": "~7.8.0",
+    "zone.js": "~0.13.0"
+  },
+  "devDependencies": {
+    "@angular/cli": "~17.0.0",
+    "@angular/compiler-cli": "~17.0.0",
+    "@types/node": "^20.0.0",
+    "typescript": "~5.2.0"
+  }
+}

--- a/saas/frontend/src/index.html
+++ b/saas/frontend/src/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>SaaS Frontend</title>
+  <base href="/">
+</head>
+<body>
+  <app-root>Loading...</app-root>
+  <script type="module" src="main.ts"></script>
+</body>
+</html>

--- a/saas/frontend/src/main.ts
+++ b/saas/frontend/src/main.ts
@@ -1,0 +1,11 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  template: '<h1>Welcome to the SaaS app</h1>'
+})
+class AppComponent {}
+
+bootstrapApplication(AppComponent).catch(err => console.error(err));

--- a/saas/frontend/tsconfig.json
+++ b/saas/frontend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc",
+    "strict": true,
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "types": []
+  }
+}


### PR DESCRIPTION
## Summary
- add sample SaaS backend using Spring Boot
- add simple Angular frontend
- include README with instructions

## Testing
- `npm test` *(fails: Invalid property `node`)*
- `gradle test` *(fails: plugin not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685e6bf8d9b8832cbf0a6181d9484cb8